### PR TITLE
Fix env bool with default on unset env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.0-alpha9
+
+- (bug) Fix bool env variable always returning default value if set to false
+
 # v1.0.0-alpha8
 
 - (feature) Add readyness module

--- a/env/env.go
+++ b/env/env.go
@@ -83,9 +83,8 @@ func Bool(key string) bool {
 }
 
 func BoolWithDefault(key string, defaultValue bool) bool {
-	value := Bool(key)
-	if !value {
+	if _, isSet := os.LookupEnv(key); !isSet {
 		return defaultValue
 	}
-	return value
+	return Bool(key)
 }


### PR DESCRIPTION
The default value was always returned instead of the actual env variable if set to false