### PR TITLE
Fix error handling in metrics middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.2
+
+- (bug) Fix error handling in metrics middleware
+
 # v1.0.1
 
 - (bug) Set correct content type when returning error messages in fiber

--- a/metrics/fiber_mectrics_middleware.go
+++ b/metrics/fiber_mectrics_middleware.go
@@ -83,5 +83,5 @@ func (m *FiberMetricsMiddleware) Handle(ctx *fiber.Ctx) error {
 		path,
 	).Observe(duration)
 
-	return nil
+	return err
 }


### PR DESCRIPTION
Fixes a bug where any unregistered route would always return `200 - OK` instead of a `404 - Not Found`. 
This is due to the middleware handler retuning no error at all to fiber.